### PR TITLE
add static list of relations

### DIFF
--- a/app/modules/users/model.js
+++ b/app/modules/users/model.js
@@ -25,7 +25,13 @@ const classProps = {
     name: function (qb, value) {
       return qb.whereIn('name', value);
     }
-  }
+  },
+  relations: [
+    'projects',
+    'presentations',
+    'community',
+    'writing'
+  ]
 };
 
 module.exports = BaseModel.extend(instanceProps, classProps);


### PR DESCRIPTION
this is presently required because bookshelf does not provide
any static analysis of models. it's also desirable because it
allows the api creator to define relations that might be used
for internal purposes that should not be accessible via the
API.
