### PR TITLE
Fix spelling: "GitHub", not "Github" [ci skip]

### DIFF
--- a/app/views/explorer.jade
+++ b/app/views/explorer.jade
@@ -14,5 +14,5 @@ block content
       pre
         textarea.u-full-width.output
       p.
-       Don't see anything? <a href="http://ashleygwilliams.github.io/explorer.html">Make sure you're not using https.</a> Find a bug? <a href="https://github.com/ashleygwilliams/ashleygwilliams.github.io/issues/new">File an issue on Github</a>
+       Don't see anything? <a href="http://ashleygwilliams.github.io/explorer.html">Make sure you're not using https.</a> Find a bug? <a href="https://github.com/ashleygwilliams/ashleygwilliams.github.io/issues/new">File an issue on GitHub</a>
   script(src="/public/js/api-browser.js", type="text/javascript")


### PR DESCRIPTION
:crystal_ball: 
